### PR TITLE
- Rename "bp_attachments_current_user_can()" to "bp_attachments_logge…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{*.json,*.yml}]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ For the "once upon a time": see [ticket 5429](https://buddypress.trac.wordpress.
 Required Configurations
 ----------------------
 
-+ Built in WordPress 3.9, should be ok with 3.8.1
-+ Requires at least BuddyPress 2.0-alpha-8020 revision 8160
++ WordPress 4.2
++ Requires at least BuddyPress 2.3.0
 
 
 Installation
@@ -27,42 +27,35 @@ About the component
 
 BP Attachments uses a specific post type `bp_attachment` to organize the files uploaded into a user's profile, or a Group if the BuddyPress Groups component is active.
 
-1. Attachments:
-  In the user's profile pages, it adds an "Attachments" subnav where to find all the files a user uploaded. If some attachments are linked to a group, a subnav for Group Attachments will be created.
-  In a single Group, if Attachments are enabled in the group settings, it adds an "Attachments" subnav where to find all files attached to the group by all its members.
-  Above the subnav in user's profile Attachments page or above the file listing in the Group Attachments page, the "Edit Attachments" button launches the "BP Media Editor" which is a customized version of the WP Media Editor for the `bp_attachment` post type.
-  You can use the "BP Media Editor" to add new attachments or manage the ones allready uploaded.
-  When on the user's Attachments page, the "BP Media Editor" Manage Attachments tab will list all the files the user uploaded. When on a group's Attachments page, the "BP Media Editor" Manage Attachments tab will list the files the user attached to the current group.
 
-  To edit the groups attached to a file, from his profile attachment page, the user can click on the 'Edit' button of the desired row. Then from the edit page, he will be able to remove his attachment from the selected group or add it to other groups.
+In the user's profile pages, it adds an "Attachments" subnav where to find all the files a user uploaded. If some attachments are linked to a group, a subnav for Group Attachments will be created.
+In a single Group, if Attachments are enabled in the group settings, it adds an "Attachments" subnav where to find all files attached to the group by all its members.
+Above the subnav in user's profile Attachments page or above the file listing in the Group Attachments page, the "Edit Attachments" button launches the "BP Media Editor" which is a customized version of the WP Media Editor for the `bp_attachment` post type.
+You can use the "BP Media Editor" to add new attachments or manage the ones allready uploaded.
+When on the user's Attachments page, the "BP Media Editor" Manage Attachments tab will list all the files the user uploaded. When on a group's Attachments page, the "BP Media Editor" Manage Attachments tab will list the files the user attached to the current group.
 
-  As the goal of this component is to help others deal with attachments, this first version "forces" the Groups component to support Attachments in order to illustrate its features. Other components can support Attachments by defining `$bp->{$component}->can_attachments` to true. In the component settings, BP Attachments will look for the component that support Attachments and will create a new term into the custom taxonomy `bp_component` using the `$bp->{$component}->name` and `$bp->{$component}->slug`.
+To edit the groups attached to a file, from his profile attachment page, the user can click on the 'Edit' button of the desired row. Then from the edit page, he will be able to remove his attachment from the selected group or add it to other groups.
 
-2. Avatars:
-  BP Attachments is managing users and groups avatars. In case of Avatars, the "BP Media Uploader" will only accept single image file upload and once the image uploaded will display it so that the user or the group Admin can crop the avatar.
+As the goal of this component is to help others deal with attachments, this first version "forces" the Groups component to support Attachments in order to illustrate its features. Other components can support Attachments by defining `$bp->{$component}->can_attachments` to true. In the component settings, BP Attachments will look for the component that support Attachments and will create a new term into the custom taxonomy `bp_component` using the `$bp->{$component}->name` and `$bp->{$component}->slug`.
 
 
-You can watch a demo of it [here](https://vimeo.com/89982937) ( mute the sound if have difficulties understanding my "franglish" ;) )  
+You can watch a demo of it [here](https://vimeo.com/89982937) ( mute the sound if have difficulties understanding my "franglish" ;) )
 
 
 
 Todos & improvements
 --------------------
 
-+ Privacy support: 
++ Privacy support:
   + See boonebgorges's work about BP Docs [wiki](https://github.com/boonebgorges/buddypress-docs/wiki/Attachment-Privacy) & [code](https://github.com/boonebgorges/buddypress-docs/blob/master/includes/attachments.php)
   + Switching from public dir to private dir if the `bp_attachment` status is 'private' into the `BP_Attachments_Upload` Class
   + Moving files from public dir to private and vice and versa in case an Attachment's status was edited by the user
 + Capabilities: need check & improvements
 + Add another way to register a new `bp_component` to allow components generated by a plugin
-+ Override the Avatar step of group creation process
 + Build the Administration screens for the Attachments so that an admin can easily moderate user's Attachments
 + Improve the Preview frame using Ajax to load the image so that a private image can be previewed and attachment details and eventual actions can be loaded in an Attachment Details view.
 + Add some styles in the edit attachment user's screen.
 + Check the translation file is loaded
 + ...
-
-
-Thanks in advance to all of you that will contribute to improve this very first version ;)
 
 

--- a/bp-attachments/bp-attachments-actions.php
+++ b/bp-attachments/bp-attachments-actions.php
@@ -170,7 +170,7 @@ function bp_attachments_catch_upload() {
 			}
 
 			// capability check
-			if ( ! bp_attachments_current_user_can( 'publish_bp_attachments', $cap_args ) ) {
+			if ( ! bp_attachments_loggedin_user_can( 'publish_bp_attachments', $cap_args ) ) {
 				bp_core_add_message( __( 'Error: you are not allowed to create this attachment.', 'bp-attachments' ), 'error' );
 				bp_core_redirect( $redirect );
 			}

--- a/bp-attachments/bp-attachments-ajax.php
+++ b/bp-attachments/bp-attachments-ajax.php
@@ -80,7 +80,7 @@ function bp_attachments_upload() {
 	}
 
 	// capability check
-	if ( ! bp_attachments_current_user_can( 'publish_bp_attachments', $cap_args ) )
+	if ( ! bp_attachments_loggedin_user_can( 'publish_bp_attachments', $cap_args ) )
 		wp_die();
 
 	$attachment_id = bp_attachments_handle_upload( $r );
@@ -122,7 +122,7 @@ function bp_attachments_ajax_delete_attachment( $action ) {
 
 	check_ajax_referer( "{$action}_$id" );
 
-	if ( ! bp_attachments_current_user_can( 'delete_bp_attachment', $id ) )
+	if ( ! bp_attachments_loggedin_user_can( 'delete_bp_attachment', $id ) )
 		wp_die( -1 );
 
 	if ( bp_attachments_delete_attachment( $id ) )
@@ -146,7 +146,7 @@ function bp_attachments_ajax_update_attachment() {
 
 	check_ajax_referer( 'update_bp_attachment_' . $id, 'nonce' );
 
-	if ( ! bp_attachments_current_user_can( 'edit_bp_attachment', $id ) )
+	if ( ! bp_attachments_loggedin_user_can( 'edit_bp_attachment', $id ) )
 		wp_send_json_error();
 
 	$changes = $_REQUEST['changes'];
@@ -194,7 +194,7 @@ function bp_attachments_upload_avatar(){
 	}
 
 	// capability check
-	if ( ! bp_attachments_current_user_can( 'edit_bp_attachments', $cap_args ) )
+	if ( ! bp_attachments_loggedin_user_can( 'edit_bp_attachments', $cap_args ) )
 		wp_die();
 
 	// If the context is avatar, make sure the uploaded file is an image.
@@ -268,7 +268,7 @@ function bp_attachments_set_avatar() {
 	}
 
 	// capability check
-	if ( ! bp_attachments_current_user_can( 'edit_bp_attachments', $cap_args ) )
+	if ( ! bp_attachments_loggedin_user_can( 'edit_bp_attachments', $cap_args ) )
 		wp_die();
 
 	// Handle crop
@@ -320,7 +320,7 @@ function bp_attachments_delete_avatar() {
 	}
 
 	// capability check
-	if ( ! bp_attachments_current_user_can( 'edit_bp_attachments', $cap_args ) )
+	if ( ! bp_attachments_loggedin_user_can( 'edit_bp_attachments', $cap_args ) )
 		wp_die();
 
 	if ( bp_core_delete_existing_avatar( array( 'item_id' => $item_id, 'object' => $object ) ) ) {

--- a/bp-attachments/bp-attachments-classes.php
+++ b/bp-attachments/bp-attachments-classes.php
@@ -281,7 +281,7 @@ class BP_Attachments_Browser {
 		if ( ! empty( $set['component'] ) && ! empty( $set['item_id'] ) )
 			$args = wp_array_slice_assoc( $set, array( 'component', 'item_id' ) );
 
-		if ( bp_attachments_current_user_can( 'publish_bp_attachments', $args ) ) {
+		if ( bp_attachments_loggedin_user_can( 'publish_bp_attachments', $args ) ) {
 			// Need some extra attribute to the wrapper
 			add_filter( 'bp_button_attachments_create-' . $set['component'] . '-' . $set['item_type'], array( __CLASS__, 'btn_extra_attribute' ), 10, 4 );
 

--- a/bp-attachments/bp-attachments-filters.php
+++ b/bp-attachments/bp-attachments-filters.php
@@ -17,12 +17,12 @@ if ( !defined( 'ABSPATH' ) ) exit;
  * @since BP Attachments (1.0.0)
  *
  * @todo really need to check this !
- * 
- * @param  array   $caps    
- * @param  string  $cap     
- * @param  integer $user_id 
- * @param  array   $args    
- * @return array   $caps           
+ *
+ * @param  array   $caps
+ * @param  string  $cap
+ * @param  integer $user_id
+ * @param  array   $args
+ * @return array   $caps
  */
 function bp_attachments_map_meta_caps( $caps = array(), $cap = '', $user_id = 0, $args = array() ) {
 
@@ -57,7 +57,7 @@ function bp_attachments_map_meta_caps( $caps = array(), $cap = '', $user_id = 0,
 
 				}
 			}
-			
+
 
 			break;
 
@@ -235,7 +235,7 @@ function bp_attachments_map_meta_caps( $caps = array(), $cap = '', $user_id = 0,
  * Custom filter for WordPress image_downsize
  *
  * @since BP Attachments (1.0.0)
- * 
+ *
  * @see bp_attachments_get_thumbnail() template function
  */
 function bp_attachments_image_downsize( $output = '', $id = 0, $size = 'medium' ) {
@@ -275,24 +275,3 @@ function bp_attachments_image_downsize( $output = '', $id = 0, $size = 'medium' 
 	}
 	return false;
 }
-
-/**
- * Override the change-avatar user template
- *
- * @since BP Attachments (1.0.0)
- * 
- * @param  array  $templates
- * @param  string $slug
- * @return array  $templates
- */
-function bp_attachments_member_avatar_template( $templates = array(), $slug = '' ) {
-
-	if ( ! bp_is_user_change_avatar() )
-		return $templates;
-
-	if ( 'members/single/profile/change-avatar' == $slug )
-		$templates = array_merge( array( 'members/single/plugins.php' ), $templates );
-	
-	return $templates;
-}
-add_filter( 'bp_get_template_part', 'bp_attachments_member_avatar_template', 10, 2 );

--- a/bp-attachments/bp-attachments-functions.php
+++ b/bp-attachments/bp-attachments-functions.php
@@ -13,7 +13,7 @@ if ( !defined( 'ABSPATH' ) ) exit;
  * Get a single attachment
  *
  * @since BP Attachments (1.0.0)
- * 
+ *
  * @param  integer $attachment_id
  * @return BP_Attachments
  */
@@ -30,14 +30,14 @@ function bp_attachments_get_attachment( $attachment_id = 0 ) {
  * Get a single attachment
  *
  * @since BP Attachments (1.0.0)
- * 
+ *
  * @param  array $args
  * @return array of BP_Attachments
  */
 function bp_attachments_get_attachments( $args = array() ) {
 
 	$defaults = array(
-		'item_ids'        => array(), // one or more item ids regarding the component (eg group_ids, message_ids ) 
+		'item_ids'        => array(), // one or more item ids regarding the component (eg group_ids, message_ids )
 		'component'	      => false,   // groups / messages / blogs / xprofile...
 		'show_private'    => false,   // wether to include private attachment
 		'user_id'	      => false,   // the author id of the attachment
@@ -45,7 +45,7 @@ function bp_attachments_get_attachments( $args = array() ) {
 		'page'		      => 1,
 		'search'          => false,
 		'exclude'		  => false,   // comma separated list or array of attachment ids.
-		'orderby' 		  => 'ID', 
+		'orderby' 		  => 'ID',
 		'order'           => 'DESC',
 	);
 
@@ -55,7 +55,7 @@ function bp_attachments_get_attachments( $args = array() ) {
 
 	if ( empty( $attachments ) ) {
 		$attachments = BP_Attachments::get( array(
-			'item_ids'        => (array) $r['item_ids'], 
+			'item_ids'        => (array) $r['item_ids'],
 			'component'	      => $r['component'],
 			'show_private'    => (bool) $r['show_private'],
 			'user_id'	      => $r['user_id'],
@@ -63,7 +63,7 @@ function bp_attachments_get_attachments( $args = array() ) {
 			'page'		      => $r['page'],
 			'search'          => $r['search'],
 			'exclude'		  => $r['exclude'],
-			'orderby' 		  => $r['orderby'], 
+			'orderby' 		  => $r['orderby'],
 			'order'           => $r['order'],
 		) );
 
@@ -77,7 +77,7 @@ function bp_attachments_get_attachments( $args = array() ) {
  * Upload attachment
  *
  * @since BP Attachments (1.0.0)
- * 
+ *
  * @param  array $args
  * @return int the id of the created attachment
  */
@@ -100,17 +100,17 @@ function bp_attachments_handle_upload( $args = array() ) {
  * Delete attachment
  *
  * @since BP Attachments (1.0.0)
- * 
+ *
  * @param  int the id of the attachment
  * @return mixed false/title of the deleted attachment
  */
 function bp_attachments_delete_attachment( $attachment_id = 0 ) {
 	if ( empty( $attachment_id ) )
 		return false;
-	
-	if ( ! bp_attachments_current_user_can( 'delete_bp_attachment', $attachment_id ) )
+
+	if ( ! bp_attachments_loggedin_user_can( 'delete_bp_attachment', $attachment_id ) )
 			return false;
-		
+
 	$deleted = BP_Attachments::delete( $attachment_id );
 
 	if ( ! empty( $deleted->post_title ) )
@@ -123,7 +123,7 @@ function bp_attachments_delete_attachment( $attachment_id = 0 ) {
  * Delete attachment
  *
  * @since BP Attachments (1.0.0)
- * 
+ *
  * @param  array $args
  * @return mixed false/title of the updated attachment
  */
@@ -143,7 +143,7 @@ function bp_attachments_update_attachment( $args = array() ) {
 	if ( empty( $id ) )
 		return false;
 
-	if ( ! bp_attachments_current_user_can( 'edit_bp_attachment', $id ) )
+	if ( ! bp_attachments_loggedin_user_can( 'edit_bp_attachment', $id ) )
 			return false;
 
 	$attachment = new BP_Attachments( $id );
@@ -178,7 +178,7 @@ function bp_attachments_update_attachment( $args = array() ) {
 					} else {
 						$to_delete = array_diff( $prev_item_ids->{$term}, $component[ $term ] );
 						$to_add    = array_diff( $component[ $term ], $prev_item_ids->{$term} );
-						
+
 						if ( ! empty( $to_delete ) ){
 							// Delete item ids
 							foreach ( $to_delete as $item_id )
@@ -262,7 +262,7 @@ function bp_attachments_get_attachment_url( $post_id = 0 ) {
  * Prepare an attachment to be displayed in the BP Media Editor
  *
  * this is an adapted copy of wp_prepare_attachment_for_js()
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_prepare_attachment_for_js( $attachment ) {
@@ -409,7 +409,7 @@ function bp_attachments_avatar_is_enabled() {
 
 /**
  * Prepare an avatar to be displayed in the BP Media Editor
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_prepare_avatar_for_js( $attachment = null ) {
@@ -435,7 +435,7 @@ function bp_attachments_prepare_avatar_for_js( $attachment = null ) {
  * Handle an avatar Upload
  *
  * This is an adapted version of bp_core_avatar_handle_upload()
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_handle_avatar_upload( $uploaded_file, $component, $item_id, $no_js = false ) {
@@ -566,17 +566,17 @@ function bp_attachments_handle_avatar_upload( $uploaded_file, $component, $item_
 
 /**
  * Register and create the upload directories
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_set_upload_dir() {
 	$upload_datas = wp_upload_dir();
-	
+
 	$bp_attachments_upload_dir = $upload_datas["basedir"] .'/bp-attachments';
 	$bp_attachments_upload_url = $upload_datas["baseurl"] .'/bp-attachments';
 
-	$bp_attachments_upload_data = array( 
-		'basedir'    => $bp_attachments_upload_dir, 
+	$bp_attachments_upload_data = array(
+		'basedir'    => $bp_attachments_upload_dir,
 		'baseurl'    => $bp_attachments_upload_url,
 		'publicdir'  => $bp_attachments_upload_dir . '/public',
 		'publicurl'  => $bp_attachments_upload_url . '/public',
@@ -588,7 +588,7 @@ function bp_attachments_set_upload_dir() {
 	if( ! file_exists( $bp_attachments_upload_dir ) ) {
 		// Create main bp-attachments dir
 		@wp_mkdir_p( $bp_attachments_upload_dir );
-		
+
 		if( ! file_exists( $bp_attachments_upload_data['publicdir'] ) ) {
 			// Create public attachments dir
 			@wp_mkdir_p( $bp_attachments_upload_data['publicdir'] );
@@ -600,30 +600,30 @@ function bp_attachments_set_upload_dir() {
 
 			/**
 			 * Create an .htaccess file to prevent files to be reached.
-			 * 
+			 *
 			 * @todo use BP Docs way to secure downloads !
 			 */
 			if( ! file_exists( $bp_attachments_upload_data['privatedir'] .'/.htaccess' ) ) {
 
 				if ( ! function_exists( 'insert_with_markers' ) )
 					require_once( ABSPATH . '/wp-admin/includes/misc.php' );
-			
+
 				// Defining the rule, we need to make it unreachable and use php to reach it
 				$rules = array( 'Order Allow,Deny','Deny from all' );
-			
+
 				// creating the .htaccess file
 				insert_with_markers( $bp_attachments_upload_data['privatedir'] .'/.htaccess', 'BuddyPress Attachments', $rules );
 			}
 		}
 	}
-	
+
 	//finally returns upload_data
 	return $bp_attachments_upload_data;
 }
 
 /**
  * bp_attachment post type caps
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_get_attachment_caps() {
@@ -639,7 +639,7 @@ function bp_attachments_get_attachment_caps() {
 
 /**
  * bp_component taxonomy caps
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_get_component_caps() {
@@ -653,7 +653,7 @@ function bp_attachments_get_component_caps() {
 
 /**
  * Specific function to check a user's capability
- * 
+ *
  * @since BP Attachments (1.0.0)
  *
  * @uses BP_Attachments_Can to create the argument to check upon
@@ -662,7 +662,7 @@ function bp_attachments_get_component_caps() {
  * - single item id
  * - attachment id
  */
-function bp_attachments_current_user_can( $capability = '', $args = false ) {
+function bp_attachments_loggedin_user_can( $capability = '', $args = false ) {
 	if ( ! empty( $args ) && is_array( $args ) )
 		$args = new BP_Attachments_Can( $args );
 
@@ -671,12 +671,12 @@ function bp_attachments_current_user_can( $capability = '', $args = false ) {
 
 	$retval = call_user_func_array( 'current_user_can_for_blog', $args );
 
-	return (bool) apply_filters( 'bp_attachments_current_user_can', $retval, $args );
+	return (bool) apply_filters( 'bp_attachments_loggedin_user_can', $retval, $args );
 }
 
 /**
  * Build the edit link of an attachement
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_get_edit_link( $attachment_id = 0, $user_id = 0 ) {
@@ -694,7 +694,7 @@ function bp_attachments_get_edit_link( $attachment_id = 0, $user_id = 0 ) {
 
 /**
  * Build the delete link of an attachement
- * 
+ *
  * @since BP Attachments (1.0.0)
  */
 function bp_attachments_get_delete_link( $attachment_id = 0, $user_id = 0 ) {

--- a/bp-attachments/bp-attachments-screens.php
+++ b/bp-attachments/bp-attachments-screens.php
@@ -63,7 +63,7 @@ class BP_Attachments_User_Screens {
 
 			$attachment = bp_attachments_get_attachment( $attachment_id );
 
-			if ( empty( $attachment ) || ! bp_attachments_current_user_can( 'edit_bp_attachment', $attachment_id ) ) {
+			if ( empty( $attachment ) || ! bp_attachments_loggedin_user_can( 'edit_bp_attachment', $attachment_id ) ) {
 				bp_core_add_message( sprintf( __( 'Attachment could not be found', 'bp-attachments' ), 'error' ) );
 				bp_core_redirect( $redirect );
 			}
@@ -79,7 +79,7 @@ class BP_Attachments_User_Screens {
 
 			$attachment_id = absint( $_POST['_bp_attachments_edit']['id'] );
 
-			if ( empty( $attachment_id ) || ! bp_attachments_current_user_can( 'edit_bp_attachment', $attachment_id ) ) {
+			if ( empty( $attachment_id ) || ! bp_attachments_loggedin_user_can( 'edit_bp_attachment', $attachment_id ) ) {
 				bp_core_add_message( sprintf( __( 'Attachment could not be edited', 'bp-attachments' ), 'error' ) );
 				bp_core_redirect( $redirect );
 			}
@@ -180,72 +180,3 @@ class BP_Attachments_User_Screens {
 function bp_attachments_screen_my_attachments() {
 	return BP_Attachments_User_Screens::register_screens();
 }
-
-/**
- * The User's new change avatar screen content
- *
- * @since BP Attachments (1.0.0)
- */
-function bp_attachments_members_change_avatar_content() {
-	if ( ! bp_is_user_change_avatar() )
-		return;
-
-	do_action( 'bp_before_profile_avatar_upload_content' );
-
-	if ( bp_attachments_avatar_is_enabled() ) : ?>
-
-		<p><?php _e( 'Your avatar will be used on your profile and throughout the site. If there is a <a href="http://gravatar.com">Gravatar</a> associated with your account email we will use that, or you can upload an image from your computer.', 'bp-attachments' ); ?></p>
-
-		<div id="bp_xprofile_avatar">
-
-			<div id="xprofile-avatar">
-		        <?php
-		        // Displays the current avatar and a link to delete it.
-		        if ( bp_get_user_has_avatar() ) {
-		            echo bp_core_fetch_avatar( array( 'item_id' => bp_displayed_user_id(), 'object' => 'user', 'type' => 'full' ) );
-		            ?>
-		            <p><a href="<?php bp_avatar_delete_link(); ?>" id="remove-xprofile-avatar"><?php esc_html_e( 'Remove Avatar', 'bp-attachments' ); ?></a></p>
-		            <?php
-		        }
-		        ?>
-	        </div>
-
-        <?php
-        // Displays the button to Change the avatar.
-        bp_attachments_browser( 'bp-avatar-upload', array(
-            'item_id'         => bp_displayed_user_id(),
-            'component'       => 'xprofile',
-            'item_type'       => 'avatar',
-            'btn_caption'     => __( 'Edit Avatar', 'bp-attachments' ),
-            'multi_selection' => false,
-            'action'          => 'bp_attachments_upload_avatar',
-            'btn_class'       => 'attachments-new-avatar'
-        ) );
-
-        do_action( 'bp_attachments_uploader_fallback' );
-        ?>
-
-        </div>
-
-	<?php else: ?>
-
-		<p><?php _e( 'Your avatar will be used on your profile and throughout the site. To change your avatar, please create an account with <a href="http://gravatar.com">Gravatar</a> using the same email address as you used to register with this site.', 'bp-attachments' ); ?></p>
-
-	<?php endif;
-
-	do_action( 'bp_after_profile_avatar_upload_content' );
-}
-add_action( 'bp_template_content', 'bp_attachments_members_change_avatar_content' );
-
-/**
- * The User's new change avatar screen title
- *
- * @since BP Attachments (1.0.0)
- */
-function bp_attachments_members_change_avatar_title() {
-	if ( ! bp_is_user_change_avatar() )
-		return;
-
-	esc_html_e( 'Change Avatar', 'bp-attachments' );
-}
-add_action( 'bp_template_title', 'bp_attachments_members_change_avatar_title' );

--- a/bp-attachments/bp-attachments-template.php
+++ b/bp-attachments/bp-attachments-template.php
@@ -684,12 +684,12 @@ add_action( 'bp_attachments_members_actions', 'bp_attachments_the_user_actions' 
 		
 		$edit = $delete = false;
 
-		if ( bp_attachments_current_user_can( 'edit_bp_attachment', $attachment_id ) ) {
+		if ( bp_attachments_loggedin_user_can( 'edit_bp_attachment', $attachment_id ) ) {
 			$edit_link = bp_attachments_get_edit_link( $attachment_id, $user_id );
 			$edit = '<a href="'. esc_url( $edit_link ) .'" class="button edit-attachment bp-primary-action" id="edit-attachment-'. $attachment_id .' ">' . _x( 'Edit', 'attachments edit link', 'bp-attachments' ) . '</a>';
 		}
 
-		if ( bp_attachments_current_user_can( 'delete_bp_attachment', $attachment_id ) ) {
+		if ( bp_attachments_loggedin_user_can( 'delete_bp_attachment', $attachment_id ) ) {
 			$delete_link = bp_attachments_get_delete_link( $attachment_id, $user_id );
 			$delete_link = wp_nonce_url( $delete_link, 'bp_attachments_delete' );
 			$delete = '<a href="'. esc_url( $delete_link ) .'" class="button delete-attachment bp-primary-action" id="delete-attachment-'. $attachment_id .' ">' . _x( 'Delete', 'attachments delete link', 'bp-attachments' ) . '</a>';

--- a/loader.php
+++ b/loader.php
@@ -12,7 +12,7 @@
  * Plugin Name:       BP Attachments
  * Plugin URI:        https://buddypress.trac.wordpress.org/ticket/5429
  * Description:       BP Attachments is a BuddyPress component to help others deal with attachments.
- * Version:           1.0.0-bleeding
+ * Version:           1.1.0-alpha
  * Author:            The BuddyPress Community
  * Author URI:        http://buddypress.org/community/members/
  * Text Domain:       bp-attachments
@@ -51,7 +51,7 @@ class BP_Attachments_Loader {
 	 *
 	 * @var      string
 	 */
-	public static $bp_version_required = '2.0-alpha-8020';
+	public static $bp_version_required = '2.3.0';
 
 	/**
 	 * Initialize the plugin
@@ -90,7 +90,7 @@ class BP_Attachments_Loader {
 	 */
 	private function setup_globals() {
 		/** BP Attachments globals ********************************************/
-		$this->version                = '1.0.0-bleeding';
+		$this->version                = '1.1.0-alpha';
 		$this->domain                 = 'bp-attachments';
 		$this->file                   = __FILE__;
 		$this->basename               = plugin_basename( $this->file );
@@ -262,7 +262,7 @@ class BP_Attachments_Loader {
 		return array_merge( $components, array(
 			'attachments' => array(
 				'title'       => __( 'Attachments', 'bp-attachments' ),
-				'description' => __( 'Utility to manage BuddyPress media elements such as avatars', 'bp-attachments' )
+				'description' => __( 'Utility to manage BuddyPress media elements', 'bp-attachments' )
  			)
 		) );
 	}


### PR DESCRIPTION
…din_user_can" to avoid a fatal with the BuddyPress Attachments API.

- Stop managing the single item avatars as the BuddyPress Attachments API is now taking care of it since BuddyPress 2.3.0.
- Bump BuddyPress required version to 2.3.0
- Bump plugin version to 1.1.0-alpha.

Fixes #13