### PR TITLE
Use a WordPress page for the BP Attachments directory

### DIFF
--- a/bp-attachments/bp-attachments-tracking.php
+++ b/bp-attachments/bp-attachments-tracking.php
@@ -531,3 +531,45 @@ function bp_attachments_tracking_output_directory_nav() {
 	</nav><!-- #bp-attachments-nav -->
 	<?php
 }
+
+/**
+ * Delete rewrite rules once the BP Attachments directory page has been mapped by BuddyPress.
+ *
+ * Doing so makes sure these rules are regenerated during next front-end page load.
+ *
+ * @since 1.0.0
+ *
+ * @param array $old_value The previous list of directory page IDs keyed with corresponding components slug.
+ * @param array $value     The updated list of directory page IDs keyed with corresponding components slug.
+ */
+function bp_attachments_admin_bp_page_mapped_clean_rewrite_rules( $old_value, $value ) {
+	if ( isset( $value['attachments'] ) && ! isset( $old_value['attachments'] ) ) {
+		delete_option( 'rewrite_rules' );
+	}
+}
+add_action( 'update_option_bp-pages', 'bp_attachments_admin_bp_page_mapped_clean_rewrite_rules', 10, 2 );
+
+/**
+ * Delete rewrite rules in case the BP Attachments directory page's slug has been updated.
+ *
+ * Doing so makes sure these rules are regenerated during next front-end page load.
+ *
+ * @since 1.0.0
+ *
+ * @param integer $post_id     The post ID.
+ * @param WP_Post $post_after  The updated version of the post object.
+ * @param WP_Post $post_before The previous version of the post object.
+ */
+function bp_attachments_admin_bp_page_updated_clean_rewrite_rules( $post_id, $post_after, $post_before ) {
+	if ( ! isset( $post_after->post_name ) || ! isset( $post_before->post_name ) ) {
+		return;
+	}
+
+	$directory_page_id = bp_core_get_directory_page_id( 'attachments' );
+
+	// There's a directory page and the user changed its slug.
+	if ( $directory_page_id && (int) $directory_page_id === (int) $post_id && $post_after->post_name !== $post_before->post_name ) {
+		delete_option( 'rewrite_rules' );
+	}
+}
+add_action( 'post_updated', 'bp_attachments_admin_bp_page_updated_clean_rewrite_rules', 10, 3 );

--- a/bp-attachments/classes/class-bp-attachments-component.php
+++ b/bp-attachments/classes/class-bp-attachments-component.php
@@ -154,11 +154,17 @@ class BP_Attachments_Component extends BP_Component {
 	 * @param array $args See BP_Component::setup_globals() for a description.
 	 */
 	public function setup_globals( $args = array() ) {
-		$bp = buddypress();
+		$bp            = buddypress();
+		$root_slug     = 'bp-attachments';
+		$has_directory = bp_is_active( $this->id, 'tracking' );
+
+		if ( $has_directory && isset( $bp->pages->{ $this->id }->slug ) ) {
+			$root_slug = $bp->pages->{ $this->id }->slug;
+		}
 
 		// Rewrite args.
 		$rewrite_args = array(
-			'root_slug'   => 'bp-attachments',
+			'root_slug'   => $root_slug,
 			'rewrite_ids' => array(
 				'directory'                    => 'bp_attachments',
 				'directory_visibility'         => 'bp_attachments_visibility',
@@ -172,7 +178,7 @@ class BP_Attachments_Component extends BP_Component {
 		// Globals for BuddyPress components.
 		$args = array(
 			'slug'                  => $this->id,
-			'has_directory'         => false,
+			'has_directory'         => $has_directory,
 			'notification_callback' => 'bp_attachments_format_notifications',
 			'directory_title'       => __( 'Community Media', 'bp-attachments' ),
 		);
@@ -718,5 +724,24 @@ class BP_Attachments_Component extends BP_Component {
 		}
 
 		parent::blocks_init( $blocks_list );
+	}
+
+	/**
+	 * Add the Attachments directory state.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array   $states Optional. See BP_Component::admin_directory_states() for description.
+	 * @param WP_Post $post   Optional. See BP_Component::admin_directory_states() for description.
+	 * @return array          See BP_Component::admin_directory_states() for description.
+	 */
+	public function admin_directory_states( $states = array(), $post = null ) {
+		$bp = buddypress();
+
+		if ( isset( $bp->pages->{ $this->id }->id ) && (int) $bp->pages->{ $this->id }->id === (int) $post->ID ) {
+			$states['page_for_attachments_directory'] = _x( 'BP Attachments Page', 'page label', 'bp-attachments' );
+		}
+
+		return parent::admin_directory_states( $states, $post );
 	}
 }


### PR DESCRIPTION
This page makes it possible to customize the root slug, and easier to include the Attachments directory into the site's navigation. 