### PR TITLE
Introduce a filter to edit how the attached media is added to the activity content

### DIFF
--- a/bp-attachments/bp-attachments-activity.php
+++ b/bp-attachments/bp-attachments-activity.php
@@ -174,7 +174,22 @@ function bp_attachments_activity_attach_media( $args = array() ) {
 		}
 
 		if ( $medium_block ) {
-			$args['content'] = $content . "\n" . $medium_block;
+			$text_block = $content;
+
+			// By default the Medium block is appended to the Activity text block.
+			$content .= "\n" . $medium_block;
+
+			/**
+			 * Filter here to edit how the attached media is added to the activity content.
+			 *
+			 * @since 1.1.0
+			 *
+			 * @param string $content      The Activity text block with the appended Medium block.
+			 * @param string $text_block   The serialized Activity text block.
+			 * @param string $medium_block The serialized Medium block.
+			 * @param array  $args         The arguments used to post an activity update.
+			 */
+			$args['content'] = apply_filters( 'bp_attachments_activity_attach_media', $content, $text_block, $medium_block, $args );
 		}
 	}
 


### PR DESCRIPTION
If you need to prepend the Medium to the activity content, you simply need to use the `bp_attachments_activity_attach_media` filter this way:

```php
/**
 * Filter to prepend the Medium to the Activity text.
 *
 * @param string $content      The Activity text block with the appended Medium block.
 * @param string $text_block   The serialized Activity text block.
 * @param string $medium_block The serialized Medium block.
 * @return string The Activity text block with the prepended Medium block.
 */
function testovac_attachments_activity_prepend_media( $content, $text_block, $medium_block ) {
	return $medium_block . "\n" . $text_block;
}
add_filter( 'bp_attachments_activity_attach_media', 'testovac_attachments_activity_prepend_media', 10, 3 );
```

Fixes #81